### PR TITLE
Update to latest caddy security plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ RUN xcaddy build \
     --with github.com/greenpau/caddy-trace@v1.1.8 \
     --with github.com/caddy-dns/cloudflare
 
-FROM caddy:2.4.6
+FROM caddy:2.6.3
 
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM caddy:2.4.2-builder AS builder
+FROM caddy:2.4.6-builder AS builder
 
 RUN xcaddy build \
-    --with github.com/greenpau/caddy-auth-portal@v1.4.6 \
-    --with github.com/greenpau/caddy-auth-jwt@v1.2.7 \
+    --with github.com/greenpau/caddy-security@v1.0.16 \
+    --with github.com/greenpau/caddy-trace@v1.1.8 \
     --with github.com/caddy-dns/cloudflare
 
-FROM caddy:2.4.2
+FROM caddy:2.4.6
 
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy


### PR DESCRIPTION
Updates the docker image to support the latest `caddy-security` plugin, as well as use the latest version of `caddy`.

Resolves #1 